### PR TITLE
Cherry pick ice_in and year_align changes from MOM6-CICE6 repo

### DIFF
--- a/datm.streams.xml
+++ b/datm.streams.xml
@@ -9,7 +9,7 @@
    <dtlimit>1.5</dtlimit>
    <year_first>1900</year_first>
    <year_last>1900</year_last>
-   <year_align>1</year_align>
+   <year_align>1900</year_align>
    <vectors>null</vectors>
    <meshfile>./input/JRA55do-ESMFmesh.nc</meshfile>
    <lev_dimname>null</lev_dimname>
@@ -30,7 +30,7 @@
    <dtlimit>1.5</dtlimit>
    <year_first>1900</year_first>
    <year_last>1900</year_last>
-   <year_align>1</year_align>
+   <year_align>1900</year_align>
    <vectors>null</vectors>
    <meshfile>./input/JRA55do-ESMFmesh.nc</meshfile>
    <lev_dimname>null</lev_dimname>
@@ -51,7 +51,7 @@
    <dtlimit>1.5</dtlimit>
    <year_first>1900</year_first>
    <year_last>1900</year_last>
-   <year_align>1</year_align>
+   <year_align>1900</year_align>
    <vectors>null</vectors>
    <meshfile>./input/JRA55do-ESMFmesh.nc</meshfile>
    <lev_dimname>null</lev_dimname>
@@ -73,7 +73,7 @@
    <dtlimit>1.5</dtlimit>
    <year_first>1900</year_first>
    <year_last>1900</year_last>
-   <year_align>1</year_align>
+   <year_align>1900</year_align>
    <vectors>null</vectors>
    <meshfile>./input/JRA55do-ESMFmesh.nc</meshfile>
    <lev_dimname>null</lev_dimname>
@@ -95,7 +95,7 @@
    <dtlimit>1.5</dtlimit>
    <year_first>1900</year_first>
    <year_last>1900</year_last>
-   <year_align>1</year_align>
+   <year_align>1900</year_align>
    <vectors>null</vectors>
    <meshfile>./input/JRA55do-ESMFmesh.nc</meshfile>
    <lev_dimname>null</lev_dimname>
@@ -117,7 +117,7 @@
    <dtlimit>1.5</dtlimit>
    <year_first>1900</year_first>
    <year_last>1900</year_last>
-   <year_align>1</year_align>
+   <year_align>1900</year_align>
    <vectors>null</vectors>
    <meshfile>./input/JRA55do-ESMFmesh.nc</meshfile>
    <lev_dimname>null</lev_dimname>
@@ -139,7 +139,7 @@
    <dtlimit>1.5</dtlimit>
    <year_first>1900</year_first>
    <year_last>1900</year_last>
-   <year_align>1</year_align>
+   <year_align>1900</year_align>
    <vectors>null</vectors>
    <meshfile>./input/JRA55do-ESMFmesh.nc</meshfile>
    <lev_dimname>null</lev_dimname>
@@ -161,7 +161,7 @@
    <dtlimit>1.5</dtlimit>
    <year_first>1900</year_first>
    <year_last>1900</year_last>
-   <year_align>1</year_align>
+   <year_align>1900</year_align>
    <vectors>null</vectors>
    <meshfile>./input/JRA55do-ESMFmesh.nc</meshfile>
    <lev_dimname>null</lev_dimname>
@@ -183,7 +183,7 @@
    <dtlimit>1.5</dtlimit>
    <year_first>1900</year_first>
    <year_last>1900</year_last>
-   <year_align>1</year_align>
+   <year_align>1900</year_align>
    <vectors>null</vectors>
    <meshfile>./input/JRA55do-ESMFmesh.nc</meshfile>
    <lev_dimname>null</lev_dimname>

--- a/drof.streams.xml
+++ b/drof.streams.xml
@@ -9,7 +9,7 @@
    <dtlimit>3.0</dtlimit>
    <year_first>1900</year_first>
    <year_last>1900</year_last>
-   <year_align>1</year_align>
+   <year_align>1900</year_align>
    <vectors>null</vectors>
    <meshfile>./input/JRA55do-ESMFmesh.nc</meshfile>
    <lev_dimname>null</lev_dimname>
@@ -30,7 +30,7 @@
    <dtlimit>3.0</dtlimit>
    <year_first>1900</year_first>
    <year_last>1900</year_last>
-   <year_align>1</year_align>
+   <year_align>1900</year_align>
    <vectors>null</vectors>
    <meshfile>./input/JRA55do-ESMFmesh.nc</meshfile>
    <lev_dimname>null</lev_dimname>

--- a/ice_in
+++ b/ice_in
@@ -1,450 +1,159 @@
 &setup_nml
-  bfbflag = "off"
+  bfbflag = "off" 
   conserv_check = .false.
-  days_per_year = 365
-  diagfreq = 24
-  dumpfreq = "x"
-  dumpfreq_n = 1
-  hist_avg = .true., .true., .true., .true., .true.
-  histfreq = "m", "x", "x", "x", "x"
-  histfreq_n = 1, 0, 0, 0, 0
-  history_file = "unknown"
-  history_format = "default"
-  history_precision = 4
+  debug_forcing = .true.
+  debug_model = .true.
+  diagfreq = 960
+  dumpfreq = "y"
+  dump_last = .true.
+  histfreq = "d", "m", "x", "x", "x"
   ice_ic = "./input/iced.1900-01-01-10800.nc"
-  latpnt = 90.0, -65.0
   lcdf64 = .true.
-  lonpnt = 0.0, -45.0
-  ndtd = 1
-  numax = 99
-  numin = 11
-  pointer_file = "./rpointer.ice"
-  print_global = .true.
-  print_points = .false.
-  restart_ext = .false.
-  restart_file = ""
-  restart_format = "default"
-  use_leap_years = .false.
-  version_name = "undefined_version_name"
-  write_ic = .false.
-  year_init = 1
+  npt = 35040
+  pointer_file      = './rpointer.ice'
+  print_global      = .false.
 /
 &grid_nml
   bathymetry_file = "./input/topog.nc"
-  bathymetry_format = "default"
-  close_boundaries = .false.
-  dxrect = 30.0e5
-  dyrect = 30.0e5
   grid_atm = "A"
   grid_file = "./input/grid.nc"
   grid_format = "nc"
   grid_ice = "B"
   grid_ocn = "A"
   grid_type = "tripole"
-  gridcpl_file = "unknown_gridcpl_file"
   kcatbound = 0
   kmt_file = "./input/kmt.nc"
-  nblyr = 3
+  nblyr = 1
   ncat = 5
   nfsd = 1
   nilyr = 4
   nslyr = 1
-  orca_halogrid = .false.
-  use_bathymetry = .false.
 /
 &tracer_nml
-  n_aero = 3
-  n_algae = 0
-  n_dic = 0
-  n_doc = 0
-  n_don = 0
-  n_fed = 0
-  n_fep = 0
-  n_iso = 3
-  n_zaero = 0
-  restart_aero = .false.
-  restart_age = .false.
-  restart_fsd = .false.
-  restart_fy = .false.
-  restart_iso = .false.
-  restart_lvl = .false.
-  restart_pond_lvl = .false.
-  restart_pond_topo = .false.
-  restart_snow = .false.
-  tr_aero = .false.
-  tr_fsd = .false.
-  tr_fy = .true.
-  tr_iage = .true.
-  tr_iso = .false.
-  tr_lvl = .true.
-  tr_pond_lvl = .true.
-  tr_pond_topo = .false.
-  tr_snow = .false.
 /
 &thermo_nml
-  a_rapid_mode = 0.5e-03
-  aspect_rapid_mode = 1.0
-  conduct = "MU71"
-  dsdt_slow_mode = -1.5e-07
-  kitd = 1
-  ktherm = 2
-  phi_c_slow_mode = 0.05
-  phi_i_mushy = 0.85
-  rac_rapid_mode = 10
+  dsdt_slow_mode = -5e-08
 /
 &dynamics_nml
   advection = "remap"
-  alphab = 20.0d0
-  arlx = 300.
-  brlx = 300.
-  cf = 17.0
-  coriolis = "latitude"
-  cstar = 20.0d0
-  e_plasticpot = 2.0
-  e_yieldcurve = 2.0
-  k1 = 8.0d0
-  k2 = 15.0d0
-  kdyn = 1
-  krdg_partic = 1
-  krdg_redist = 1
-  kridge = 1
-  kstrength = 1
-  ktens = 0.0
-  ktransport = 1
-  mu_rdg = 4.0
-  ndte = 120
-  pstar = 2.75d4
-  revised_evp = .false.
-  seabed_stress = .false.
-  seabed_stress_method = "LKD"
   ssh_stress = "coupled"
-  threshold_hw = 30.0d0
 /
 &shortwave_nml
-  ahmax = 0.3
-  albedo_type = "default"
-  albicei = 0.45
-  albicev = 0.75
-  albsnowi = 0.73
+  ahmax = 0.1
+  albicei = 0.44
+  albicev = 0.86
+  albsnowi = 0.7
   albsnowv = 0.98
-  dt_mlt = 1.50
   kalg = 0.0
-  r_ice = 0.0
-  r_pnd = 0.0
-  r_snw = 1.25
-  rsnw_mlt = 1500.
-  shortwave = "dEdd"
-  sw_dtemp = 0.01d0
-  sw_frac = 1.0d0
+  r_snw = 0.0
   sw_redist = .true.
 /
 &ponds_nml
   dpscale = 1.0e-3
-  frzpnd = "cesm"
-  hp1 = 0.01
-  hs0 = 0.0
-  hs1 = 0.03
-  pndaspect = 0.8
-  rfracmax = 0.85
-  rfracmin = 0.15
+  frzpnd = "hlid"
+  rfracmax = 1.0
 /
 &snow_nml
-  drhosdwind = 27.3
-  rhosmax = 450.0
-  rhosmin = 100.0
-  rhosnew = 100.0
-  rsnw_fall = 100.0
-  rsnw_tmax = 1500.0
-  snw_T_fname = "unknown"
-  snw_Tgrd_fname = "unknown"
-  snw_aging_table = "test"
-  snw_drdt0_fname = "unknown"
-  snw_filename = "unknown"
-  snw_kappa_fname = "unknown"
-  snw_rhos_fname = "unknown"
-  snw_tau_fname = "unknown"
-  snwgrain = .false.
-  snwlvlfac = 0.3
-  snwredist = "none"
-  use_smliq_pnd = .false.
-  windmin = 10.0
 /
 &forcing_nml
-  atmbndy = "default"
-  calc_strair = .true.
-  calc_tsfc = .true.
   emissivity = 0.95d0
-  fbot_xfer_type = "constant"
-  formdrag = .false.
+  ice_ref_salinity = 5.0d0
   highfreq = .true.
-  ice_ref_salinity = 4.0d0
-  l_mpond_fresh = .false.
-  natmiter = 5
-  nfreq = 25
-  restart_coszen = .false.
-  rotate_wind = .true.
-  saltflux_option = "prognostic"
-  tfrz_option = "mushy"
+  tfrz_option = "linear_salt"
   update_ocn_f = .true.
-  ustar_min = 0.005
-  wave_spec_file = "unknown_wave_spec_file"
-  wave_spec_type = "none"
+  ustar_min = 0.0005
 /
 &domain_nml
-  add_mpi_barriers = .false.
-  block_size_x = 20
-  block_size_y = 16
-  distribution_type = "sectrobin"
-  distribution_wght = "blockall"
-  ew_boundary_type = "cyclic"
+  block_size_x = 16
+  block_size_y = 15
+  distribution_type = "cartesian"
+  distribution_wght = "latitude"
   maskhalo_bound = .true.
   maskhalo_dyn = .true.
   maskhalo_remap = .true.
-  max_blocks = 8
+  max_blocks = 10
   ns_boundary_type = "tripole"
   nx_global = 360
   ny_global = 300
-  processor_shape = "square-ice"
+  processor_shape = "slenderX2"
 /
 &ice_prescribed_nml
-  prescribed_ice_mode = .false.
-  stream_datafiles = ""
-  stream_mapalgo = "na"
-  stream_meshfile = ""
-  stream_varname = "ice_cov"
-  stream_yearalign = -999
-  stream_yearfirst = -999
-  stream_yearlast = -999
 /
 &zbgc_nml
-  bgc_flux_type = "Jin2006"
-  dEdd_algae = .false.
-  modal_aero = .false.
-  restart_bgc = .false.
-  restart_hbrine = .false.
-  restart_zsal = .false.
-  restore_bgc = .false.
-  scale_bgc = .false.
-  skl_bgc = .false.
-  solve_zbgc = .false.
-  solve_zsal = .false.
-  tr_bgc_Am = .false.
-  tr_bgc_C = .false.
-  tr_bgc_DMS = .false.
-  tr_bgc_DON = .false.
-  tr_bgc_Fe = .false.
-  tr_bgc_Nit = .false.
-  tr_bgc_PON = .false.
-  tr_bgc_Sil = .false.
-  tr_bgc_chl = .false.
-  tr_bgc_hum = .false.
-  tr_brine = .false.
-  tr_zaero = .false.
-  z_tracers = .false.
 /
 &icefields_bgc_nml
-  f_aero = "xxxxx"
-  f_bgc_c = "xxxxx"
-  f_bgc_chl = "xxxxx"
-  f_bgc_dms = "xxxxx"
-  f_bgc_dmspd = "xxxxx"
-  f_bgc_dmspp = "xxxxx"
-  f_bgc_n = "xxxxx"
-  f_bgc_s = "xxxxx"
-  f_bgc_sil = "xxxxx"
-  f_bphi = "xxxxx"
-  f_faero_atm = "xxxxx"
-  f_faero_ocn = "xxxxx"
-  f_grownet = "xxxxx"
-  f_ppnet = "xxxxx"
 /
 &icefields_drag_nml
-  f_cdn_atm = "xxxxx"
-  f_cdn_ocn = "xxxxx"
-  f_drag = "xxxxx"
 /
 &icefields_fsd_nml
-  f_afsd = "xxxxx"
-  f_dafsd_latg = "xxxxx"
-  f_dafsd_latm = "xxxxx"
-  f_dafsd_newi = "xxxxx"
-  f_dafsd_wave = "xxxxx"
-  f_dafsd_weld = "xxxxx"
 /
 &icefields_mechred_nml
-  f_alvl = "xxxxx"
-  f_aparticn = "xxxxx"
-  f_araftn = "xxxxx"
-  f_ardg = "mxxxx"
-  f_ardgn = "xxxxx"
-  f_aredistn = "xxxxx"
-  f_dardg1dt = "xxxxx"
-  f_dardg1ndt = "xxxxx"
-  f_dardg2dt = "xxxxx"
-  f_dardg2ndt = "xxxxx"
-  f_dvirdgdt = "xxxxx"
-  f_dvirdgndt = "xxxxx"
-  f_krdgn = "xxxxx"
-  f_opening = "xxxxx"
-  f_vlvl = "xxxxx"
-  f_vraftn = "xxxxx"
-  f_vrdg = "xxxxx"
-  f_vrdgn = "xxxxx"
-  f_vredistn = "xxxxx"
+  !-----------------------------------
+  ! These fields are on by default (in ice_history_mechred.F90) but lets turn them off
+  !-----------------------------------
+  f_dardg1dt  = 'x', f_dardg2dt   = 'x'
+  f_dvirdgdt  = 'x'
 /
 &icefields_pond_nml
-  f_apeff = "xxxxx"
-  f_apeff_ai = "mxxxx"
-  f_apeffn = "xxxxx"
-  f_apond = "xxxxx"
-  f_apond_ai = "mdxxx"
-  f_apondn = "xxxxx"
-  f_hpond = "xxxxx"
-  f_hpond_ai = "mxxxx"
-  f_hpondn = "xxxxx"
-  f_ipond = "xxxxx"
-  f_ipond_ai = "xxxxx"
 /
 &icefields_snow_nml
-  f_fsloss = "mxxxx"
-  f_meltsliq = "mxxxx"
-  f_rhos_cmp = "mxxxx"
-  f_rhos_cmpn = "xxxxx"
-  f_rhos_cnt = "mxxxx"
-  f_rhos_cntn = "xxxxx"
-  f_rsnw = "mxxxx"
-  f_rsnwn = "xxxxx"
-  f_smassice = "mxxxx"
-  f_smassicen = "xxxxx"
-  f_smassliq = "mxxxx"
-  f_smassliqn = "xxxxx"
+  f_fsloss = "m"
+  f_meltsliq = "m"
+  f_rhos_cmp = "m"
+  f_rhos_cnt = "m"
+  f_rsnw = "m"
+  f_smassice = "m"
+  f_smassliq = "m"
 /
 &icefields_nml
-  f_aice = "mdhxx"
-  f_aicen = "mdhxx"
-  f_aisnap = "xxxxx"
-  f_albice = "xxxxx"
-  f_albpnd = "xxxxx"
-  f_albsni = "mxxxx"
-  f_albsno = "xxxxx"
-  f_alidf = "xxxxx"
-  f_alidf_ai = "mxxxx"
-  f_alidr = "xxxxx"
-  f_alidr_ai = "mxxxx"
-  f_alvdf = "xxxxx"
-  f_alvdf_ai = "mxxxx"
-  f_alvdr = "xxxxx"
-  f_alvdr_ai = "mxxxx"
-  f_angle = .true.
-  f_anglet = .true.
-  f_blkmask = .false.
-  f_bounds = .true.
-  f_cmip = "xxxxx"
-  f_congel = "mdxxx"
-  f_coszen = "xxxxx"
-  f_daidtd = "mdxxx"
-  f_daidtt = "mdxxx"
-  f_divu = "mxxxx"
-  f_dsnow = "xxxxx"
-  f_dvidtd = "mdxxx"
-  f_dvidtt = "mdxxx"
-  f_dxt = .true.
-  f_dxu = .true.
-  f_dyt = .true.
-  f_dyu = .true.
-  f_evap = "mxxxx"
-  f_evap_ai = "xxxxx"
-  f_fcondtop_ai = "xxxxx"
-  f_fcondtopn_ai = "xxxxx"
-  f_fhocn = "mxxxx"
-  f_fhocn_ai = "xxxxx"
-  f_flat = "mxxxx"
-  f_flat_ai = "mxxxx"
-  f_flatn_ai = "xxxxx"
-  f_flwdn = "mxxxx"
-  f_flwup = "mxxxx"
-  f_flwup_ai = "xxxxx"
-  f_fmeltt_ai = "xxxxx"
-  f_fmelttn_ai = "xxxxx"
-  f_frazil = "mdxxx"
-  f_fresh = "mxxxx"
-  f_fresh_ai = "xxxxx"
-  f_frz_onset = "xxxxx"
-  f_frzmlt = "xxxxx"
-  f_fsalt = "mxxxx"
-  f_fsalt_ai = "xxxxx"
-  f_fsens = "mxxxx"
-  f_fsens_ai = "mxxxx"
-  f_fsensn_ai = "xxxxx"
-  f_fsurf_ai = "xxxxx"
-  f_fsurfn_ai = "xxxxx"
-  f_fswabs = "mdhxx"
-  f_fswabs_ai = "xxxxx"
-  f_fswdn = "mdhxx"
-  f_fswfac = "xxxxx"
-  f_fswint_ai = "xxxxx"
-  f_fswthru = "mdhxx"
-  f_fswthru_ai = "xxxxx"
-  f_fswup = "mxxxx"
-  f_fy = "xxxxx"
-  f_hi = "mdhxx"
-  f_hisnap = "xxxxx"
-  f_hs = "mdhxx"
-  f_hte = .true.
-  f_htn = .true.
-  f_iage = "xxxxx"
-  f_icepresent = "mxxxx"
-  f_keffn_top = "xxxxx"
-  f_meltb = "mdxxx"
-  f_meltl = "mdxxx"
-  f_melts = "mdxxx"
-  f_meltt = "mdxxx"
-  f_mlt_onset = "xxxxx"
-  f_ncat = .true.
-  f_qref = "xxxxx"
-  f_rain = "mxxxx"
-  f_rain_ai = "xxxxx"
-  f_shear = "mxxxx"
-  f_sice = "xxxxx"
-  f_sig1 = "mxxxx"
-  f_sig2 = "mxxxx"
-  f_sinz = "xxxxx"
-  f_snoice = "mxxxx"
-  f_snow = "mxxxx"
-  f_snow_ai = "xxxxx"
-  f_snowfrac = "mxxxx"
-  f_snowfracn = "xxxxx"
-  f_sss = "xxxxx"
-  f_sst = "xxxxx"
-  f_strairx = "mxxxx"
-  f_strairy = "mxxxx"
-  f_strcorx = "mxxxx"
-  f_strcory = "mxxxx"
-  f_strength = "mxxxx"
-  f_strintx = "mxxxx"
-  f_strinty = "mxxxx"
-  f_strocnx = "mxxxx"
-  f_strocny = "mxxxx"
-  f_strtltx = "mxxxx"
-  f_strtlty = "mxxxx"
-  f_tair = "xxxxx"
-  f_tarea = .true.
-  f_tinz = "xxxxx"
-  f_tmask = .true.
-  f_tref = "xxxxx"
-  f_trsig = "xxxxx"
-  f_tsfc = "mxxxx"
-  f_tsnz = "xxxxx"
-  f_uarea = .true.
-  f_uatm = "mxxxx"
-  f_uocn = "xxxxx"
-  f_uvel = "mxxxx"
-  f_vatm = "mxxxx"
-  f_vgrdb = .true.
-  f_vgrdi = .true.
-  f_vgrds = .true.
-  f_vicen = "mdhxx"
-  f_vocn = "xxxxx"
-  f_vsnon = "mdhxx"
-  f_vvel = "mxxxx"
+  f_aice = "md"
+  f_aicen = "m"
+  f_bounds = .false.
+  f_fcondtopn_ai = "m"
+  f_congel = "md"
+  f_dvidtd = "md"
+  f_dvidtt = "md"
+  f_fmelttn_ai = "m"
+  f_frzmlt = "md"
+  f_frazil = "md"
+  f_flatn_ai   = "m"
+  f_fsens_ai = "m"
+  f_fsensn_ai = "m"
+  f_fsurfn_ai = "m"
+  f_hi = "md"
+  f_hs = "md"
+  f_snoice = "md"
+  f_uvel = "md" , f_vvel = "md"
+  f_vicen = "m"
+  !-----------------------------------
+  ! These fields are on by default (in ice_history_shared.F90) but lets turn them off
+  !-----------------------------------
+  f_albpnd = 'x'
+  f_atmdir = 'x' , f_atmspd = 'x'
+  f_coszen = 'x'
+  f_dsnow = 'x'
+  f_evap = 'x'
+  f_fbot = 'x'
+  f_fhocn = 'x'
+  f_flat = 'x'
+  f_fresh = 'x'
+  f_fswthru = 'x'
+  f_fsurf_ai = 'x'
+  f_hisnap = 'x', f_aisnap = 'x',
+  f_icedir = 'x'
+  f_icespd = 'x'
+  f_mlt_onset = 'x', f_frz_onset  = 'x'
+  f_ocndir = 'x' , f_ocnspd = 'x'
+  f_rain = 'x'
+  f_fsens = 'x'
+  f_flwup = 'x'
+  f_sig1 = 'x', f_sig2 = 'x'
+  f_sigP = 'x'
+  f_snow = 'x'
+  f_sst = 'x'
+  f_sss = 'x'
+  f_fswabs = 'x'
+  f_taubx = 'x' , f_tauby = 'x'
+  f_Tref = 'x', f_Qref = 'x'
+  f_uocn = 'x' , f_vocn = 'x'
 /

--- a/nuopc.runconfig
+++ b/nuopc.runconfig
@@ -293,7 +293,7 @@ CLOCK_attributes::
      restart_ymd = -999
      rof_cpl_dt = 3600
      start_tod = 0
-     start_ymd = 00010101
+     start_ymd = 19000101
      stop_n = 1
      stop_option = nmonths
      stop_tod = 0

--- a/ww3_shel.nml
+++ b/ww3_shel.nml
@@ -2,7 +2,7 @@
 ! - but rather by driver config variables
 ! See w3nmlshelmd.F90 for the definition of the data types used below
 &domain_nml
- domain%start = '00010101 0'
+ domain%start = '19000101 0'
  domain%stop  = '99990101 0'
 /
 &input_nml
@@ -17,17 +17,17 @@
 /
 &output_date_nml
   date%field%outffile  = '1'
-  date%field%start     = '00010101 0'
+  date%field%start     = '19000101 0'
   date%field%stride    = '86400'
   date%field%stop      = '99990101 0'
   date%point%outffile  = '0'
-  date%point%start     = '00010101 0'
+  date%point%start     = '19000101 0'
   date%point%stride    = '0'
   date%point%stop      = '99990101 0'  
-  date%restart%start   = '00010101 0'
+  date%restart%start   = '19000101 0'
   date%restart%stride  = '3600'
   date%restart%stop    = '99990101 0'
-  date%restart2%start  = '99990101 0'
+  date%restart2%start  = '19000101 0'
   date%restart2%stride = '0'
   date%restart2%stop   = '99990101 0'
 /


### PR DESCRIPTION
I cherry picked recent config changes from MOM6-CICE6 repo:

I noted two things when running this:

- Do we need to set the dates in 'ww3_shel.nml' now we have changed them in datm/drof streams xml files?
- The dates on the history output are wrong:
```
ncdump archive/output001/GMOM_JRA_WD.ww3.hi.1900-01-03-00000.nc | grep time
        time = UNLIMITED ; // (1 currently)
        double time(time) ;
                time:units = "seconds since 1900-01-02 00:00:00" ;
                time:calendar = "noleap" ;
        int mapsta(time, ny, nx) ;
        float UAX(time, ny, nx) ;
        float UAY(time, ny, nx) ;
        float ICE(time, ny, nx) ;
        float HS(time, ny, nx) ;
        float T02(time, ny, nx) ;
        float T0M1(time, ny, nx) ;
        float T01(time, ny, nx) ;
        float FP0(time, ny, nx) ;
        float THM(time, ny, nx) ;
        float EF(time, freq, ny, nx) ;
        float USSX(time, ny, nx) ;
        float USSY(time, ny, nx) ;
 time = 172800 ;
```

Note the `time:units` are seconds since 1900-01-02, but the the time is 172800 (= 2 days). This gives a date of 1900-01-04 00:00:00, however the expected result is the output represents the average from 1900-01-02 00:00:00 to 1900-01-02 24:00:00. Is this a known issue @ezhilsabareesh8 ?

(n.b., I set nuopc.runconfig stop and restart to 1 day, and wav history_n to 1 day, and ran twice in Payu)