### PR TITLE
1deg_jra55do_ryf: change case name to "access-om3"

### DIFF
--- a/diag_table
+++ b/diag_table
@@ -1,151 +1,151 @@
-"MOM6 diagnostic fields table for CESM case: GMOM_JRA_WD"
+"MOM6 diagnostic fields table"
 1 1 1 0 0 0
 ### Section-1: File List
 #========================
-"GMOM_JRA_WD.mom6.h.rho2%4yr-%2mo",                      1,  "months", 1, "days",   "time", 1, "months"
-"GMOM_JRA_WD.mom6.h.native%4yr-%2mo",                    1,  "months", 1, "days",   "time", 1, "months"
-"GMOM_JRA_WD.mom6.h.z%4yr-%2mo",                         1,  "months", 1, "days",   "time", 1, "months"
-"GMOM_JRA_WD.mom6.h.sfc%4yr-%2mo",                       1,  "days",   1, "days",   "time", 1, "months"
-"GMOM_JRA_WD.mom6.h.static",                             -1, "days",   1, "days",   "time"
+"access-om3.mom6.h.rho2%4yr-%2mo",                      1,  "months", 1, "days",   "time", 1, "months"
+"access-om3.mom6.h.native%4yr-%2mo",                    1,  "months", 1, "days",   "time", 1, "months"
+"access-om3.mom6.h.z%4yr-%2mo",                         1,  "months", 1, "days",   "time", 1, "months"
+"access-om3.mom6.h.sfc%4yr-%2mo",                       1,  "days",   1, "days",   "time", 1, "months"
+"access-om3.mom6.h.static",                             -1, "days",   1, "days",   "time"
 
 ### Section-2: Fields List
 #=========================
-# "GMOM_JRA_WD.mom6.h.rho2%4yr-%2mo"
-"ocean_model_rho2", "volcello","volcello","GMOM_JRA_WD.mom6.h.rho2%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model_rho2", "vmo",     "vmo",     "GMOM_JRA_WD.mom6.h.rho2%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model_rho2", "vhGM",    "vhGM",    "GMOM_JRA_WD.mom6.h.rho2%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model_rho2", "vhml",    "vhml",    "GMOM_JRA_WD.mom6.h.rho2%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model_rho2", "umo",     "umo",     "GMOM_JRA_WD.mom6.h.rho2%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model_rho2", "uhGM",    "uhGM",    "GMOM_JRA_WD.mom6.h.rho2%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model_rho2", "uhml",    "uhml",    "GMOM_JRA_WD.mom6.h.rho2%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model_rho2", "thetao",  "thetao",  "GMOM_JRA_WD.mom6.h.rho2%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model_rho2", "so",      "so",      "GMOM_JRA_WD.mom6.h.rho2%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model_rho2", "agessc",  "agessc",  "GMOM_JRA_WD.mom6.h.rho2%4yr-%2mo", "all", "mean", "none", 2
+# "access-om3.mom6.h.rho2%4yr-%2mo"
+"ocean_model_rho2", "volcello","volcello","access-om3.mom6.h.rho2%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model_rho2", "vmo",     "vmo",     "access-om3.mom6.h.rho2%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model_rho2", "vhGM",    "vhGM",    "access-om3.mom6.h.rho2%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model_rho2", "vhml",    "vhml",    "access-om3.mom6.h.rho2%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model_rho2", "umo",     "umo",     "access-om3.mom6.h.rho2%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model_rho2", "uhGM",    "uhGM",    "access-om3.mom6.h.rho2%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model_rho2", "uhml",    "uhml",    "access-om3.mom6.h.rho2%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model_rho2", "thetao",  "thetao",  "access-om3.mom6.h.rho2%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model_rho2", "so",      "so",      "access-om3.mom6.h.rho2%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model_rho2", "agessc",  "agessc",  "access-om3.mom6.h.rho2%4yr-%2mo", "all", "mean", "none", 2
 
-# "GMOM_JRA_WD.mom6.h.native%4yr-%2mo"
-"ocean_model", "soga",         "soga",         "GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "thetaoga",     "thetaoga",     "GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "uh",           "uh",           "GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "vh",           "vh",           "GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "vhbt",         "vhbt",         "GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "uhbt",         "uhbt",         "GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "agessc",       "agessc",       "GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "T_ady_2d",     "T_ady_2d",     "GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "T_adx_2d",     "T_adx_2d",     "GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "T_diffy_2d",   "T_diffy_2d",   "GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "T_diffx_2d",   "T_diffx_2d",   "GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "diftrelo",     "diftrelo",     "GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "diftrblo",     "diftrblo",     "GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "difmxybo",     "difmxybo",     "GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "difmxylo",     "difmxylo",     "GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "volcello",     "volcello",     "GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "vmo",          "vmo",          "GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "vhGM",         "vhGM",         "GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "vhml",         "vhml",         "GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "umo",          "umo",          "GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "uhGM",         "uhGM",         "GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "uhml",         "uhml",         "GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "uo",           "uo",           "GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "vo",           "vo",           "GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "h",            "h",            "GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "e",            "e",            "GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "thetao",       "thetao",       "GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "so",           "so",           "GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "KE",           "KE",           "GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "rhopot0",      "rhopot0",      "GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "KPP_OBLdepth", "oml",          "GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "tauuo",        "tauuo",        "GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "tauvo",        "tauvo",        "GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "friver",       "friver",       "GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "prsn",         "prsn",         "GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "prlq",         "prlq",         "GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "evs",          "evs",          "GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "hfsso",        "hfsso",        "GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "rlntds",       "rlntds",       "GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "hfsnthermds",  "hfsnthermds",  "GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "sfdsi",        "sfdsi",        "GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "rsntds",       "rsntds",       "GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "hfds",         "hfds",         "GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "ustar",        "ustar",        "GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "hfsifrazil",   "hfsifrazil",   "GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "wfo",          "wfo",          "GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "vprec",        "vprec",        "GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "ficeberg",     "ficeberg",     "GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "fsitherm",     "fsitherm",     "GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "hflso",        "hflso",        "GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "pso",          "pso",          "GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "seaice_melt_heat","seaice_melt_heat","GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "Heat_PmE",     "Heat_PmE",     "GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "salt_flux_added","salt_flux_added","GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "heat_content_lrunoff","heat_content_lrunoff","GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "heat_content_frunoff","heat_content_frunoff","GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "heat_content_lprec","heat_content_lprec","GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "heat_content_fprec","heat_content_fprec","GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "heat_content_vprec","heat_content_vprec","GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "heat_content_cond","heat_content_cond","GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "heat_content_evap","heat_content_evap","GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "SSH",          "SSH",          "GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "tos",          "tos",          "GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "sos",          "sos",          "GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "SSU",          "SSU",          "GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "SSV",          "SSV",          "GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "mass_wt",      "mass_wt",      "GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "opottempmint", "opottempmint", "GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "somint",       "somint",       "GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "Rd_dx",        "Rd_dx",        "GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "speed",        "speed",        "GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "mlotst",       "mlotst",       "GMOM_JRA_WD.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+# "access-om3.mom6.h.native%4yr-%2mo"
+"ocean_model", "soga",         "soga",         "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "thetaoga",     "thetaoga",     "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "uh",           "uh",           "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "vh",           "vh",           "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "vhbt",         "vhbt",         "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "uhbt",         "uhbt",         "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "agessc",       "agessc",       "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "T_ady_2d",     "T_ady_2d",     "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "T_adx_2d",     "T_adx_2d",     "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "T_diffy_2d",   "T_diffy_2d",   "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "T_diffx_2d",   "T_diffx_2d",   "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "diftrelo",     "diftrelo",     "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "diftrblo",     "diftrblo",     "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "difmxybo",     "difmxybo",     "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "difmxylo",     "difmxylo",     "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "volcello",     "volcello",     "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "vmo",          "vmo",          "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "vhGM",         "vhGM",         "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "vhml",         "vhml",         "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "umo",          "umo",          "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "uhGM",         "uhGM",         "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "uhml",         "uhml",         "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "uo",           "uo",           "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "vo",           "vo",           "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "h",            "h",            "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "e",            "e",            "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "thetao",       "thetao",       "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "so",           "so",           "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "KE",           "KE",           "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "rhopot0",      "rhopot0",      "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "KPP_OBLdepth", "oml",          "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "tauuo",        "tauuo",        "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "tauvo",        "tauvo",        "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "friver",       "friver",       "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "prsn",         "prsn",         "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "prlq",         "prlq",         "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "evs",          "evs",          "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "hfsso",        "hfsso",        "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "rlntds",       "rlntds",       "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "hfsnthermds",  "hfsnthermds",  "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "sfdsi",        "sfdsi",        "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "rsntds",       "rsntds",       "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "hfds",         "hfds",         "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "ustar",        "ustar",        "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "hfsifrazil",   "hfsifrazil",   "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "wfo",          "wfo",          "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "vprec",        "vprec",        "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "ficeberg",     "ficeberg",     "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "fsitherm",     "fsitherm",     "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "hflso",        "hflso",        "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "pso",          "pso",          "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "seaice_melt_heat","seaice_melt_heat","access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "Heat_PmE",     "Heat_PmE",     "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "salt_flux_added","salt_flux_added","access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "heat_content_lrunoff","heat_content_lrunoff","access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "heat_content_frunoff","heat_content_frunoff","access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "heat_content_lprec","heat_content_lprec","access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "heat_content_fprec","heat_content_fprec","access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "heat_content_vprec","heat_content_vprec","access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "heat_content_cond","heat_content_cond","access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "heat_content_evap","heat_content_evap","access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "SSH",          "SSH",          "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "tos",          "tos",          "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "sos",          "sos",          "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "SSU",          "SSU",          "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "SSV",          "SSV",          "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "mass_wt",      "mass_wt",      "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "opottempmint", "opottempmint", "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "somint",       "somint",       "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "Rd_dx",        "Rd_dx",        "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "speed",        "speed",        "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "mlotst",       "mlotst",       "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
 
-# "GMOM_JRA_WD.mom6.h.z%4yr-%2mo"
-"ocean_model_z", "uo",      "uo",      "GMOM_JRA_WD.mom6.h.z%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model_z", "vo",      "vo",      "GMOM_JRA_WD.mom6.h.z%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model_z", "h",       "h",       "GMOM_JRA_WD.mom6.h.z%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model_z", "thetao",  "thetao",  "GMOM_JRA_WD.mom6.h.z%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model_z", "so",      "so",      "GMOM_JRA_WD.mom6.h.z%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model_z", "agessc",  "agessc",  "GMOM_JRA_WD.mom6.h.z%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model_z", "rhopot0", "rhopot0", "GMOM_JRA_WD.mom6.h.z%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model_z", "N2_int",  "N2_int",  "GMOM_JRA_WD.mom6.h.z%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model_z", "volcello","volcello","GMOM_JRA_WD.mom6.h.z%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model_z", "vmo",     "vmo",     "GMOM_JRA_WD.mom6.h.z%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model_z", "vhGM",    "vhGM",    "GMOM_JRA_WD.mom6.h.z%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model_z", "vhml",    "vhml",    "GMOM_JRA_WD.mom6.h.z%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model_z", "umo",     "umo",     "GMOM_JRA_WD.mom6.h.z%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model_z", "uhGM",    "uhGM",    "GMOM_JRA_WD.mom6.h.z%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model_z", "uhml",    "uhml",    "GMOM_JRA_WD.mom6.h.z%4yr-%2mo", "all", "mean", "none", 2
+# "access-om3.mom6.h.z%4yr-%2mo"
+"ocean_model_z", "uo",      "uo",      "access-om3.mom6.h.z%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model_z", "vo",      "vo",      "access-om3.mom6.h.z%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model_z", "h",       "h",       "access-om3.mom6.h.z%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model_z", "thetao",  "thetao",  "access-om3.mom6.h.z%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model_z", "so",      "so",      "access-om3.mom6.h.z%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model_z", "agessc",  "agessc",  "access-om3.mom6.h.z%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model_z", "rhopot0", "rhopot0", "access-om3.mom6.h.z%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model_z", "N2_int",  "N2_int",  "access-om3.mom6.h.z%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model_z", "volcello","volcello","access-om3.mom6.h.z%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model_z", "vmo",     "vmo",     "access-om3.mom6.h.z%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model_z", "vhGM",    "vhGM",    "access-om3.mom6.h.z%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model_z", "vhml",    "vhml",    "access-om3.mom6.h.z%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model_z", "umo",     "umo",     "access-om3.mom6.h.z%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model_z", "uhGM",    "uhGM",    "access-om3.mom6.h.z%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model_z", "uhml",    "uhml",    "access-om3.mom6.h.z%4yr-%2mo", "all", "mean", "none", 2
 
-# "GMOM_JRA_WD.mom6.h.sfc%4yr-%2mo"
-"ocean_model", "SSH",          "SSH",          "GMOM_JRA_WD.mom6.h.sfc%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "tos",          "tos",          "GMOM_JRA_WD.mom6.h.sfc%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "sos",          "sos",          "GMOM_JRA_WD.mom6.h.sfc%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "SSU",          "SSU",          "GMOM_JRA_WD.mom6.h.sfc%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "SSV",          "SSV",          "GMOM_JRA_WD.mom6.h.sfc%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "mass_wt",      "mass_wt",      "GMOM_JRA_WD.mom6.h.sfc%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "opottempmint", "opottempmint", "GMOM_JRA_WD.mom6.h.sfc%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "somint",       "somint",       "GMOM_JRA_WD.mom6.h.sfc%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "Rd_dx",        "Rd_dx",        "GMOM_JRA_WD.mom6.h.sfc%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "speed",        "speed",        "GMOM_JRA_WD.mom6.h.sfc%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "mlotst",       "mlotst",       "GMOM_JRA_WD.mom6.h.sfc%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "KPP_OBLdepth", "oml",          "GMOM_JRA_WD.mom6.h.sfc%4yr-%2mo", "all", "mean", "none", 2
+# "access-om3.mom6.h.sfc%4yr-%2mo"
+"ocean_model", "SSH",          "SSH",          "access-om3.mom6.h.sfc%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "tos",          "tos",          "access-om3.mom6.h.sfc%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "sos",          "sos",          "access-om3.mom6.h.sfc%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "SSU",          "SSU",          "access-om3.mom6.h.sfc%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "SSV",          "SSV",          "access-om3.mom6.h.sfc%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "mass_wt",      "mass_wt",      "access-om3.mom6.h.sfc%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "opottempmint", "opottempmint", "access-om3.mom6.h.sfc%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "somint",       "somint",       "access-om3.mom6.h.sfc%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "Rd_dx",        "Rd_dx",        "access-om3.mom6.h.sfc%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "speed",        "speed",        "access-om3.mom6.h.sfc%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "mlotst",       "mlotst",       "access-om3.mom6.h.sfc%4yr-%2mo", "all", "mean", "none", 2
+"ocean_model", "KPP_OBLdepth", "oml",          "access-om3.mom6.h.sfc%4yr-%2mo", "all", "mean", "none", 2
 
-# "GMOM_JRA_WD.mom6.h.static"
-"ocean_model", "geolon",      "geolon",      "GMOM_JRA_WD.mom6.h.static", "all", ".false.", "none", 2
-"ocean_model", "geolat",      "geolat",      "GMOM_JRA_WD.mom6.h.static", "all", ".false.", "none", 2
-"ocean_model", "geolon_c",    "geolon_c",    "GMOM_JRA_WD.mom6.h.static", "all", ".false.", "none", 2
-"ocean_model", "geolat_c",    "geolat_c",    "GMOM_JRA_WD.mom6.h.static", "all", ".false.", "none", 2
-"ocean_model", "geolon_u",    "geolon_u",    "GMOM_JRA_WD.mom6.h.static", "all", ".false.", "none", 2
-"ocean_model", "geolat_u",    "geolat_u",    "GMOM_JRA_WD.mom6.h.static", "all", ".false.", "none", 2
-"ocean_model", "geolon_v",    "geolon_v",    "GMOM_JRA_WD.mom6.h.static", "all", ".false.", "none", 2
-"ocean_model", "geolat_v",    "geolat_v",    "GMOM_JRA_WD.mom6.h.static", "all", ".false.", "none", 2
-"ocean_model", "deptho",      "deptho",      "GMOM_JRA_WD.mom6.h.static", "all", ".false.", "none", 2
-"ocean_model", "wet",         "wet",         "GMOM_JRA_WD.mom6.h.static", "all", ".false.", "none", 2
-"ocean_model", "wet_c",       "wet_c",       "GMOM_JRA_WD.mom6.h.static", "all", ".false.", "none", 2
-"ocean_model", "wet_u",       "wet_u",       "GMOM_JRA_WD.mom6.h.static", "all", ".false.", "none", 2
-"ocean_model", "wet_v",       "wet_v",       "GMOM_JRA_WD.mom6.h.static", "all", ".false.", "none", 2
-"ocean_model", "Coriolis",    "Coriolis",    "GMOM_JRA_WD.mom6.h.static", "all", ".false.", "none", 2
-"ocean_model", "areacello",   "areacello",   "GMOM_JRA_WD.mom6.h.static", "all", ".false.", "none", 2
-"ocean_model", "areacello_cu","areacello_cu","GMOM_JRA_WD.mom6.h.static", "all", ".false.", "none", 2
-"ocean_model", "areacello_cv","areacello_cv","GMOM_JRA_WD.mom6.h.static", "all", ".false.", "none", 2
-"ocean_model", "areacello_bu","areacello_bu","GMOM_JRA_WD.mom6.h.static", "all", ".false.", "none", 2
-"ocean_model", "sin_rot",     "sin_rot",     "GMOM_JRA_WD.mom6.h.static", "all", ".false.", "none", 2
-"ocean_model", "cos_rot",     "cos_rot",     "GMOM_JRA_WD.mom6.h.static", "all", ".false.", "none", 2
+# "access-om3.mom6.h.static"
+"ocean_model", "geolon",      "geolon",      "access-om3.mom6.h.static", "all", ".false.", "none", 2
+"ocean_model", "geolat",      "geolat",      "access-om3.mom6.h.static", "all", ".false.", "none", 2
+"ocean_model", "geolon_c",    "geolon_c",    "access-om3.mom6.h.static", "all", ".false.", "none", 2
+"ocean_model", "geolat_c",    "geolat_c",    "access-om3.mom6.h.static", "all", ".false.", "none", 2
+"ocean_model", "geolon_u",    "geolon_u",    "access-om3.mom6.h.static", "all", ".false.", "none", 2
+"ocean_model", "geolat_u",    "geolat_u",    "access-om3.mom6.h.static", "all", ".false.", "none", 2
+"ocean_model", "geolon_v",    "geolon_v",    "access-om3.mom6.h.static", "all", ".false.", "none", 2
+"ocean_model", "geolat_v",    "geolat_v",    "access-om3.mom6.h.static", "all", ".false.", "none", 2
+"ocean_model", "deptho",      "deptho",      "access-om3.mom6.h.static", "all", ".false.", "none", 2
+"ocean_model", "wet",         "wet",         "access-om3.mom6.h.static", "all", ".false.", "none", 2
+"ocean_model", "wet_c",       "wet_c",       "access-om3.mom6.h.static", "all", ".false.", "none", 2
+"ocean_model", "wet_u",       "wet_u",       "access-om3.mom6.h.static", "all", ".false.", "none", 2
+"ocean_model", "wet_v",       "wet_v",       "access-om3.mom6.h.static", "all", ".false.", "none", 2
+"ocean_model", "Coriolis",    "Coriolis",    "access-om3.mom6.h.static", "all", ".false.", "none", 2
+"ocean_model", "areacello",   "areacello",   "access-om3.mom6.h.static", "all", ".false.", "none", 2
+"ocean_model", "areacello_cu","areacello_cu","access-om3.mom6.h.static", "all", ".false.", "none", 2
+"ocean_model", "areacello_cv","areacello_cv","access-om3.mom6.h.static", "all", ".false.", "none", 2
+"ocean_model", "areacello_bu","areacello_bu","access-om3.mom6.h.static", "all", ".false.", "none", 2
+"ocean_model", "sin_rot",     "sin_rot",     "access-om3.mom6.h.static", "all", ".false.", "none", 2
+"ocean_model", "cos_rot",     "cos_rot",     "access-om3.mom6.h.static", "all", ".false.", "none", 2
 

--- a/manifests/input.yaml
+++ b/manifests/input.yaml
@@ -4,8 +4,8 @@ version: 1.0
 work/input/JRA55do-ESMFmesh.nc:
   fullpath: /g/data/ik11/inputs/access-om3/0.x.0/share/meshes/JRA55do-ESMFmesh.nc
   hashes:
-    binhash: 5195a7517bd0905add0f97ceecc0503f
-    md5: 154215afc3b742e3da9ac77e4eac6813
+    binhash: 1147443c3fe237a480af1b4700159e21
+    md5: 1c8481b8c85f59b6cbfc2ed5bc24c77d
 work/input/RYF.friver.1990_1991.nc:
   fullpath: /g/data/ik11/inputs/JRA-55/RYF/v1-4/RYF.friver.1990_1991.nc
   hashes:
@@ -69,13 +69,13 @@ work/input/RYF.vas.1990_1991.nc:
 work/input/access-om2-1deg-ESMFmesh.nc:
   fullpath: /g/data/ik11/inputs/access-om3/0.x.0/1deg/share/access-om2-1deg-ESMFmesh.nc
   hashes:
-    binhash: b76768044950ac2a165e3c2cd70e2f56
-    md5: 670568bbb1f7f14c534b37ec895af118
+    binhash: c741e080783ac65f2a2e67a9cfdb7645
+    md5: 44e508ac57b244fc357faf5b12933bed
 work/input/access-om2-1deg-nomask-ESMFmesh.nc:
   fullpath: /g/data/ik11/inputs/access-om3/0.x.0/1deg/share/access-om2-1deg-nomask-ESMFmesh.nc
   hashes:
-    binhash: 25269214daf2808dbf536f434b707b71
-    md5: d40d8512d683a089b6feb343d903ad71
+    binhash: 491167fde697289421ff25be582d001d
+    md5: 9b7120a42b5cb587492e7c31791eb549
 work/input/grid.nc:
   fullpath: /g/data/ik11/inputs/access-om3/0.x.0/1deg/cice/grid.nc
   hashes:
@@ -654,8 +654,8 @@ work/input/make_ryf/make_ryf.py:
 work/input/mod_def.ww3:
   fullpath: /g/data/ik11/inputs/access-om3/0.x.0/1deg/ww3/mod_def.ww3
   hashes:
-    binhash: 37421525cd3e587c82dae788be663f60
-    md5: f05ce20560ac68008bd9d76ce05b47d3
+    binhash: 915b4515e318fa96f87d36e434d21f11
+    md5: 9e259b3b0138660bb91a52d2b73a3c8b
 work/input/ocean_hgrid.nc:
   fullpath: /g/data/ik11/inputs/access-om3/0.x.0/1deg/mom/ocean_hgrid.nc
   hashes:
@@ -674,8 +674,8 @@ work/input/ocean_vgrid.nc:
 work/input/restart.ww3:
   fullpath: /g/data/ik11/inputs/access-om3/0.x.0/1deg/ww3/restart.ww3
   hashes:
-    binhash: cb36d35e6ee91fc8ab086db8626d82de
-    md5: db8c0fe5cb4ef31b5143a64e80eb1f76
+    binhash: 537ed25ca109fa454ad2bab2399df57c
+    md5: 6ace1d88a3d35563b542cf81afb8fa92
 work/input/salt_sfc_restore.nc:
   fullpath: /g/data/ik11/inputs/access-om3/0.x.0/1deg/mom/salt_sfc_restore.nc
   hashes:

--- a/nuopc.runconfig
+++ b/nuopc.runconfig
@@ -89,7 +89,7 @@ ALLCOMP_attributes::
      WAV_model = ww3dev
      brnch_retain_casename = .false.
      case_desc = UNSET
-     case_name = GMOM_JRA_WD
+     case_name = access-om3
      cism_evolve = .false.
      coldair_outbreak_mod = .false.
      data_assimilation_atm = .false.


### PR DESCRIPTION
This PR changes the case name from "GMOM_JRA" to "access-om3". See https://github.com/COSIMA/access-om3/issues/106. The input manifests are also updated so that the hashes reflect what is in the inputs directory. @anton-seaice, before you ask, I don't know why the `mod_def.ww3` and `restart.ww3` inputs have changed. @ezhilsabareesh8 may know?

The plan is to add a check to the ACCESS-OM3 Payu driver to check that the naming in the MOM `diag_table` is consistent with the case name set in `nuopc.runconfig`.

Once this PR is merged, I'll cherry pick into `1deg_jra55do_iaf`.