### PR TITLE
1deg_jra55do_ryf: update OM3 executable to latest version

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -37,11 +37,3 @@ input:
  
 collate: false
 runlog: false
-
-modules:
-  use:
-      - /g/data/ik11/spack/0.20.1/modules/access-om3/0.x.0/linux-rocky8-cascadelake
-  load:
-      - intel-compiler/2021.6.0
-      - openmpi/4.1.4
-      - parallelio/2.5.10

--- a/config.yaml
+++ b/config.yaml
@@ -18,7 +18,7 @@ jobname: 1deg_jra55do_ryf
 
 model: access-om3
 
-exe: /g/data/ik11/inputs/access-om3/bin/access-om3-MOM6-CICE6-WW3-3965e25
+exe: /g/data/ik11/spack/0.21.2/opt/linux-rocky8-cascadelake/intel-2021.10.0/access-om3-d6813d6b9e1df560ac3f6ba6a605daab9cfd9569_main-5pjh7z2/bin/access-om3-MOM6-CICE6-WW3
 input: 
     - /g/data/vk83/experiments/inputs/access-om3/share/meshes/global.1deg/2024.01.25/access-om2-1deg-ESMFmesh.nc
     - /g/data/vk83/experiments/inputs/access-om3/share/meshes/global.1deg/2024.01.25/access-om2-1deg-nomask-ESMFmesh.nc

--- a/fd.yaml
+++ b/fd.yaml
@@ -487,6 +487,18 @@
        canonical_units: m
        description: atmosphere import
      #
+     - standard_name: So_ugustOut
+       canonical_units: m/s
+       description: atmosphere import
+     #
+     - standard_name: So_u10withGust
+       canonical_units: m/s
+       description: atmosphere import
+     #
+     - standard_name: So_u10res
+       canonical_units: m/s
+       description: atmosphere import
+     #
      #-----------------------------------
      # section: land-ice export
      # Note that the fields sent from glc->med do NOT have elevation classes,

--- a/ice_in
+++ b/ice_in
@@ -8,7 +8,6 @@
   dump_last = .true.
   histfreq = "d", "m", "x", "x", "x"
   ice_ic = "./input/iced.1900-01-01-10800.nc"
-  lcdf64 = .true.
   npt = 35040
   pointer_file      = './rpointer.ice'
   print_global      = .false.

--- a/manifests/exe.yaml
+++ b/manifests/exe.yaml
@@ -1,8 +1,8 @@
 format: yamanifest
 version: 1.0
 ---
-work/access-om3-MOM6-CICE6-WW3-3965e25:
-  fullpath: /g/data/ik11/inputs/access-om3/bin/access-om3-MOM6-CICE6-WW3-3965e25
+work/access-om3-MOM6-CICE6-WW3:
+  fullpath: /g/data/ik11/spack/0.21.2/opt/linux-rocky8-cascadelake/intel-2021.10.0/access-om3-d6813d6b9e1df560ac3f6ba6a605daab9cfd9569_main-5pjh7z2/bin/access-om3-MOM6-CICE6-WW3
   hashes:
-    binhash: 7e82f075b9973133cb94e9a122b87f69
-    md5: 54b6ce08150477a14e06f83aa5a55ff1
+    binhash: d2afe6b3357989154d7929fc32f830e6
+    md5: 76621df7fdb8ee046fc546320ac5de27


### PR DESCRIPTION
This configuration was missed in a recent update. See https://github.com/COSIMA/MOM6-CICE6-WW3/pull/22 for the same change in a different configuration.

Closes https://github.com/COSIMA/access-om3/issues/133