### PR TITLE
Unset `MAX_DELTA_SRESTORE`: `1deg_jra55do_iaf`

### DIFF
--- a/MOM_input
+++ b/MOM_input
@@ -316,10 +316,6 @@ FLUXCONST = 0.11
                                 ! to the relative surface anomalies (akin to a piston
                                 ! velocity).  Note the non-MKS units."
 
-MAX_DELTA_SRESTORE = 0.5
-                                ! "[PSU or g kg-1] default = 999.0
-                                ! The maximum salinity difference used in restoring terms."
-
 SRESTORE_AS_SFLUX = True
                                 ! "[Boolean] default = False
                                 ! If true, the restoring of salinity is applied as a salt


### PR DESCRIPTION
Unsets `MAX_DELTA_SRESTORE` in MOM_input so that it takes the default `MAX_DELTA_SRESTORE = 999.0`. See https://github.com/COSIMA/access-om3/issues/167