### PR TITLE
Meaningless values for {model_name}_cpl_dt in nuopc.runconfig

### DIFF
--- a/nuopc.runconfig
+++ b/nuopc.runconfig
@@ -279,19 +279,19 @@ MED_attributes::
 ::
 
 CLOCK_attributes::
-     atm_cpl_dt = 3600
+     atm_cpl_dt = 99999 #not used
      calendar = NO_LEAP
      end_restart = .false.
      glc_avg_period = yearly
-     glc_cpl_dt = 86400
+     glc_cpl_dt = 99999 #not used
      history_ymd = -999
-     ice_cpl_dt = 3600
-     lnd_cpl_dt = 3600
+     ice_cpl_dt = 99999 #not used
+     lnd_cpl_dt = 99999 #not used
      ocn_cpl_dt = 3600
      restart_n = 1
      restart_option = ndays
      restart_ymd = -999
-     rof_cpl_dt = 3600
+     rof_cpl_dt = 99999 #not used
      start_tod = 0
      start_ymd = 19000101
      stop_n = 1
@@ -301,7 +301,7 @@ CLOCK_attributes::
      tprof_n = -999
      tprof_option = never
      tprof_ymd = -999
-     wav_cpl_dt = 3600
+     wav_cpl_dt = 99999 #not used
 ::
 
 ATM_attributes::


### PR DESCRIPTION
This PR address https://github.com/COSIMA/access-om3/issues/132 by setting meaningless values for {model_name}_cpl_dt in nuopc.runconfig .