### PR TITLE
Update to latest ACCESS-OM3 executable: `1deg_jra55do_iaf`

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -19,7 +19,7 @@ jobname: 1deg_jra55do_iaf
 
 model: access-om3
 
-exe: /g/data/ik11/spack/0.21.2/opt/linux-rocky8-cascadelake/intel-2021.10.0/access-om3-d6813d6b9e1df560ac3f6ba6a605daab9cfd9569_main-5pjh7z2/bin/access-om3-MOM6-CICE6-WW3
+exe: /g/data/ik11/spack/0.21.2/opt/linux-rocky8-cascadelake/intel-2021.10.0/access-om3-69f719964a27e23deae3923d60af01a081cc3fc0_main-fkzzqnp/bin/access-om3-MOM6-CICE6-WW3
 input: 
     - /g/data/vk83/experiments/inputs/access-om3/share/meshes/global.1deg/2024.01.25/access-om2-1deg-ESMFmesh.nc
     - /g/data/vk83/experiments/inputs/access-om3/share/meshes/global.1deg/2024.01.25/access-om2-1deg-nomask-ESMFmesh.nc

--- a/manifests/exe.yaml
+++ b/manifests/exe.yaml
@@ -2,7 +2,7 @@ format: yamanifest
 version: 1.0
 ---
 work/access-om3-MOM6-CICE6-WW3:
-  fullpath: /g/data/ik11/spack/0.21.2/opt/linux-rocky8-cascadelake/intel-2021.10.0/access-om3-d6813d6b9e1df560ac3f6ba6a605daab9cfd9569_main-5pjh7z2/bin/access-om3-MOM6-CICE6-WW3
+  fullpath: /g/data/ik11/spack/0.21.2/opt/linux-rocky8-cascadelake/intel-2021.10.0/access-om3-69f719964a27e23deae3923d60af01a081cc3fc0_main-fkzzqnp/bin/access-om3-MOM6-CICE6-WW3
   hashes:
-    binhash: d2afe6b3357989154d7929fc32f830e6
-    md5: 76621df7fdb8ee046fc546320ac5de27
+    binhash: b281583fa59e6b0ef755e24aee4303ee
+    md5: 2eb399f40b49a51cfaa0c621adfb381d


### PR DESCRIPTION
This PR updates the ACCESS-OM3 executable to include recent code changes. See https://github.com/COSIMA/access-om3/issues/183